### PR TITLE
Implement basic admin panel

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,10 +2,12 @@ import { Routes } from '@angular/router';
 import { HomeComponent } from './pages/home/home.component';
 import { JoinUsComponent } from './pages/join-us/join-us.component';
 import { RegisterComponent } from './pages/register/register.component';
+import { AdminComponent } from './pages/admin/admin.component';
 
 export const routes: Routes = [
   { path: '', component: HomeComponent },
   { path: 'join-us', component: JoinUsComponent },
   { path: 'register', component: RegisterComponent },
+  { path: 'admin', component: AdminComponent },
   { path: '**', redirectTo: '' }
-]; 
+];

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -3,11 +3,21 @@ import { HomeComponent } from './pages/home/home.component';
 import { JoinUsComponent } from './pages/join-us/join-us.component';
 import { RegisterComponent } from './pages/register/register.component';
 import { AdminComponent } from './pages/admin/admin.component';
+import { DashboardComponent } from './pages/admin/dashboard/dashboard.component';
+import { SubmissionsComponent } from './pages/admin/submissions.component';
 
 export const routes: Routes = [
   { path: '', component: HomeComponent },
   { path: 'join-us', component: JoinUsComponent },
   { path: 'register', component: RegisterComponent },
-  { path: 'admin', component: AdminComponent },
+  {
+    path: 'admin',
+    component: AdminComponent,
+    children: [
+      { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
+      { path: 'dashboard', component: DashboardComponent },
+      { path: 'submissions', component: SubmissionsComponent }
+    ]
+  },
   { path: '**', redirectTo: '' }
 ];

--- a/src/app/components/shared/header/header.component.html
+++ b/src/app/components/shared/header/header.component.html
@@ -30,13 +30,21 @@
           <span class="material-icons">group</span>
           הצטרפות
         </a>
-        <a 
-          routerLink="/register" 
+        <a
+          routerLink="/register"
           routerLinkActive="active"
           class="nav-link"
         >
           <span class="material-icons">event</span>
           הרשמה לפעילויות
+        </a>
+        <a
+          routerLink="/admin"
+          routerLinkActive="active"
+          class="nav-link"
+        >
+          <span class="material-icons">admin_panel_settings</span>
+          ניהול
         </a>
       </nav>
 

--- a/src/app/pages/admin/admin.component.html
+++ b/src/app/pages/admin/admin.component.html
@@ -2,49 +2,16 @@
   <mat-sidenav mode="side" opened class="admin-sidenav">
     <mat-toolbar color="primary">ניהול</mat-toolbar>
     <mat-nav-list>
-      <a mat-list-item>רשומות</a>
+      <a mat-list-item routerLink="dashboard" routerLinkActive="active">דשבורד</a>
+      <a mat-list-item routerLink="submissions" routerLinkActive="active">רשומות</a>
     </mat-nav-list>
   </mat-sidenav>
   <mat-sidenav-content>
-    <mat-toolbar color="primary">
+    <mat-toolbar color="primary" class="toolbar">
       <span>לוח ניהול</span>
-      <span class="spacer"></span>
-      <button mat-icon-button (click)="openAddDialog()">
-        <mat-icon>add</mat-icon>
-      </button>
     </mat-toolbar>
     <div class="content">
-      <table mat-table [dataSource]="submissions" class="mat-elevation-z1" multiTemplateDataRows>
-        <ng-container matColumnDef="user">
-          <th mat-header-cell *matHeaderCellDef>משתמש</th>
-          <td mat-cell *matCellDef="let s">{{ s.userIdentity }}</td>
-        </ng-container>
-        <ng-container matColumnDef="formType">
-          <th mat-header-cell *matHeaderCellDef>טופס</th>
-          <td mat-cell *matCellDef="let s">{{ s.formName }}</td>
-        </ng-container>
-        <ng-container matColumnDef="timestamp">
-          <th mat-header-cell *matHeaderCellDef>תאריך</th>
-          <td mat-cell *matCellDef="let s">{{ s.timestamp | date:'short' }}</td>
-        </ng-container>
-        <ng-container matColumnDef="status">
-          <th mat-header-cell *matHeaderCellDef>סטטוס</th>
-          <td mat-cell *matCellDef="let s">{{ s.status }}</td>
-        </ng-container>
-        <ng-container matColumnDef="actions">
-          <th mat-header-cell *matHeaderCellDef>פעולות</th>
-          <td mat-cell *matCellDef="let s">
-            <button mat-icon-button color="primary" (click)="markProcessed(s)">
-              <mat-icon>check</mat-icon>
-            </button>
-            <button mat-icon-button color="warn" (click)="deleteSubmission(s.id!)">
-              <mat-icon>delete</mat-icon>
-            </button>
-          </td>
-        </ng-container>
-        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-      </table>
+      <router-outlet></router-outlet>
     </div>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/src/app/pages/admin/admin.component.html
+++ b/src/app/pages/admin/admin.component.html
@@ -1,0 +1,50 @@
+<mat-sidenav-container class="admin-container">
+  <mat-sidenav mode="side" opened class="admin-sidenav">
+    <mat-toolbar color="primary">ניהול</mat-toolbar>
+    <mat-nav-list>
+      <a mat-list-item (click)="">רשומות</a>
+    </mat-nav-list>
+  </mat-sidenav>
+  <mat-sidenav-content>
+    <mat-toolbar color="primary">
+      <span>לוח ניהול</span>
+      <span class="spacer"></span>
+      <button mat-icon-button (click)="openAddDialog()">
+        <mat-icon>add</mat-icon>
+      </button>
+    </mat-toolbar>
+    <div class="content">
+      <table mat-table [dataSource]="submissions" class="mat-elevation-z1" multiTemplateDataRows>
+        <ng-container matColumnDef="user">
+          <th mat-header-cell *matHeaderCellDef>משתמש</th>
+          <td mat-cell *matCellDef="let s">{{ s.userIdentity }}</td>
+        </ng-container>
+        <ng-container matColumnDef="formType">
+          <th mat-header-cell *matHeaderCellDef>טופס</th>
+          <td mat-cell *matCellDef="let s">{{ s.formName }}</td>
+        </ng-container>
+        <ng-container matColumnDef="timestamp">
+          <th mat-header-cell *matHeaderCellDef>תאריך</th>
+          <td mat-cell *matCellDef="let s">{{ s.timestamp | date:'short' }}</td>
+        </ng-container>
+        <ng-container matColumnDef="status">
+          <th mat-header-cell *matHeaderCellDef>סטטוס</th>
+          <td mat-cell *matCellDef="let s">{{ s.status }}</td>
+        </ng-container>
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef>פעולות</th>
+          <td mat-cell *matCellDef="let s">
+            <button mat-icon-button color="primary" (click)="markProcessed(s)">
+              <mat-icon>check</mat-icon>
+            </button>
+            <button mat-icon-button color="warn" (click)="deleteSubmission(s.id!)">
+              <mat-icon>delete</mat-icon>
+            </button>
+          </td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+      </table>
+    </div>
+  </mat-sidenav-content>
+</mat-sidenav-container>

--- a/src/app/pages/admin/admin.component.html
+++ b/src/app/pages/admin/admin.component.html
@@ -1,16 +1,93 @@
 <mat-sidenav-container class="admin-container">
-  <mat-sidenav mode="side" opened class="admin-sidenav">
-    <mat-toolbar color="primary">ניהול</mat-toolbar>
-    <mat-nav-list>
-      <a mat-list-item routerLink="dashboard" routerLinkActive="active">דשבורד</a>
-      <a mat-list-item routerLink="submissions" routerLinkActive="active">רשומות</a>
+  <!-- Sidebar -->
+  <mat-sidenav #sidenav mode="side" opened class="admin-sidenav" [fixedInViewport]="true">
+    <!-- Logo/Brand Section -->
+    <div class="sidenav-header">
+      <div class="brand-section">
+        <div class="logo-container">
+          <mat-icon class="logo-icon">eco</mat-icon>
+        </div>
+        <h2 class="brand-name">קו טאו סאנפלואר</h2>
+        <p class="brand-subtitle">לוח ניהול</p>
+      </div>
+    </div>
+
+    <!-- User Profile Section -->
+    <div class="user-profile">
+      <div class="user-avatar">
+        <mat-icon>account_circle</mat-icon>
+      </div>
+      <div class="user-info">
+        <h4 class="user-name">מנהל המערכת</h4>
+        <p class="user-role">Administrator</p>
+      </div>
+    </div>
+
+    <!-- Navigation Menu -->
+    <mat-nav-list class="nav-menu">
+      <a mat-list-item routerLink="dashboard" routerLinkActive="active" class="nav-item">
+        <mat-icon matListItemIcon>dashboard</mat-icon>
+        <span matListItemTitle>דשבורד</span>
+      </a>
+      
+      <a mat-list-item routerLink="submissions" routerLinkActive="active" class="nav-item">
+        <mat-icon matListItemIcon>assignment</mat-icon>
+        <span matListItemTitle>הגשות</span>
+        <span matListItemMeta class="badge">12</span>
+      </a>
+      
+      <a mat-list-item routerLink="activities" routerLinkActive="active" class="nav-item">
+        <mat-icon matListItemIcon>event</mat-icon>
+        <span matListItemTitle>פעילויות</span>
+      </a>
+      
+      <a mat-list-item routerLink="members" routerLinkActive="active" class="nav-item">
+        <mat-icon matListItemIcon>people</mat-icon>
+        <span matListItemTitle>חברי קהילה</span>
+      </a>
+      
+      <a mat-list-item routerLink="settings" routerLinkActive="active" class="nav-item">
+        <mat-icon matListItemIcon>settings</mat-icon>
+        <span matListItemTitle>הגדרות</span>
+      </a>
     </mat-nav-list>
+
+    <!-- Bottom Section -->
+    <div class="sidenav-footer">
+      <button mat-button class="logout-btn" (click)="logout()">
+        <mat-icon>logout</mat-icon>
+        <span>התנתק</span>
+      </button>
+    </div>
   </mat-sidenav>
-  <mat-sidenav-content>
-    <mat-toolbar color="primary" class="toolbar">
-      <span>לוח ניהול</span>
+
+  <!-- Main Content Area -->
+  <mat-sidenav-content class="main-content">
+    <!-- Top Toolbar -->
+    <mat-toolbar class="top-toolbar">
+      <div class="toolbar-left">
+        <button mat-icon-button (click)="sidenav.toggle()" class="menu-toggle">
+          <mat-icon>menu</mat-icon>
+        </button>
+        <div class="breadcrumb">
+          <span class="breadcrumb-item">לוח ניהול</span>
+          <mat-icon class="breadcrumb-separator">chevron_right</mat-icon>
+          <span class="breadcrumb-item active">{{ getCurrentPageTitle() }}</span>
+        </div>
+      </div>
+      
+      <div class="toolbar-right">
+        <button mat-icon-button class="notification-btn">
+          <mat-icon [matBadge]="3" matBadgeColor="warn">notifications</mat-icon>
+        </button>
+        <button mat-icon-button class="profile-btn">
+          <mat-icon>account_circle</mat-icon>
+        </button>
+      </div>
     </mat-toolbar>
-    <div class="content">
+
+    <!-- Page Content -->
+    <div class="page-content">
       <router-outlet></router-outlet>
     </div>
   </mat-sidenav-content>

--- a/src/app/pages/admin/admin.component.html
+++ b/src/app/pages/admin/admin.component.html
@@ -2,7 +2,7 @@
   <mat-sidenav mode="side" opened class="admin-sidenav">
     <mat-toolbar color="primary">ניהול</mat-toolbar>
     <mat-nav-list>
-      <a mat-list-item (click)="">רשומות</a>
+      <a mat-list-item>רשומות</a>
     </mat-nav-list>
   </mat-sidenav>
   <mat-sidenav-content>

--- a/src/app/pages/admin/admin.component.scss
+++ b/src/app/pages/admin/admin.component.scss
@@ -4,9 +4,11 @@
 .admin-sidenav {
   width: 200px;
 }
+.toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
 .content {
   padding: 1rem;
-}
-.spacer {
-  flex: 1 1 auto;
 }

--- a/src/app/pages/admin/admin.component.scss
+++ b/src/app/pages/admin/admin.component.scss
@@ -1,0 +1,12 @@
+.admin-container {
+  height: 100%;
+}
+.admin-sidenav {
+  width: 200px;
+}
+.content {
+  padding: 1rem;
+}
+.spacer {
+  flex: 1 1 auto;
+}

--- a/src/app/pages/admin/admin.component.scss
+++ b/src/app/pages/admin/admin.component.scss
@@ -1,14 +1,278 @@
+// Variables
+$primary-color: #1976d2;
+$primary-light: #42a5f5;
+$primary-dark: #1565c0;
+$accent-color: #ff9800;
+$success-color: #4caf50;
+$warning-color: #ff9800;
+$error-color: #f44336;
+$text-primary: #212121;
+$text-secondary: #757575;
+$background-light: #fafafa;
+$background-dark: #f5f5f5;
+$border-color: #e0e0e0;
+$shadow-light: 0 2px 4px rgba(0,0,0,0.1);
+$shadow-medium: 0 4px 8px rgba(0,0,0,0.12);
+$shadow-heavy: 0 8px 16px rgba(0,0,0,0.15);
+
+// Main Container
 .admin-container {
-  height: 100%;
+  height: 100vh;
+  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
 }
+
+// Sidebar Styles
 .admin-sidenav {
-  width: 200px;
+  width: 280px;
+  background: linear-gradient(180deg, #1976d2 0%, #1565c0 100%);
+  border: none;
+  box-shadow: $shadow-heavy;
+  
+  .sidenav-header {
+    padding: 24px 20px;
+    border-bottom: 1px solid rgba(255,255,255,0.1);
+    
+    .brand-section {
+      text-align: center;
+      
+      .logo-container {
+        width: 60px;
+        height: 60px;
+        margin: 0 auto 16px;
+        background: rgba(255,255,255,0.2);
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        
+        .logo-icon {
+          font-size: 32px;
+          color: white;
+        }
+      }
+      
+      .brand-name {
+        color: white;
+        font-size: 18px;
+        font-weight: 600;
+        margin: 0 0 4px;
+        text-align: center;
+      }
+      
+      .brand-subtitle {
+        color: rgba(255,255,255,0.8);
+        font-size: 12px;
+        margin: 0;
+        text-align: center;
+      }
+    }
+  }
+  
+  .user-profile {
+    padding: 20px;
+    border-bottom: 1px solid rgba(255,255,255,0.1);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    
+    .user-avatar {
+      width: 48px;
+      height: 48px;
+      background: rgba(255,255,255,0.2);
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      
+      mat-icon {
+        color: white;
+        font-size: 24px;
+      }
+    }
+    
+    .user-info {
+      flex: 1;
+      
+      .user-name {
+        color: white;
+        font-size: 14px;
+        font-weight: 500;
+        margin: 0 0 2px;
+      }
+      
+      .user-role {
+        color: rgba(255,255,255,0.7);
+        font-size: 12px;
+        margin: 0;
+      }
+    }
+  }
+  
+  .nav-menu {
+    padding: 16px 0;
+    
+    .nav-item {
+      margin: 4px 16px;
+      border-radius: 8px;
+      transition: all 0.3s ease;
+      
+      &:hover {
+        background: rgba(255,255,255,0.1);
+      }
+      
+      &.active {
+        background: rgba(255,255,255,0.2);
+        box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        
+        mat-icon {
+          color: white;
+        }
+        
+        span {
+          color: white;
+          font-weight: 500;
+        }
+      }
+      
+      mat-icon {
+        color: rgba(255,255,255,0.8);
+        margin-right: 12px;
+      }
+      
+      span {
+        color: rgba(255,255,255,0.9);
+        font-size: 14px;
+      }
+      
+      .badge {
+        background: $accent-color;
+        color: white;
+        padding: 2px 8px;
+        border-radius: 12px;
+        font-size: 11px;
+        font-weight: 500;
+      }
+    }
+  }
+  
+  .sidenav-footer {
+    padding: 20px;
+    border-top: 1px solid rgba(255,255,255,0.1);
+    margin-top: auto;
+    
+    .logout-btn {
+      width: 100%;
+      color: rgba(255,255,255,0.8);
+      border-radius: 8px;
+      transition: all 0.3s ease;
+      
+      &:hover {
+        background: rgba(255,255,255,0.1);
+        color: white;
+      }
+      
+      mat-icon {
+        margin-right: 8px;
+      }
+    }
+  }
 }
-.toolbar {
-  position: sticky;
-  top: 0;
-  z-index: 1;
+
+// Main Content Area
+.main-content {
+  background: $background-light;
+  
+  .top-toolbar {
+    background: white;
+    box-shadow: $shadow-light;
+    border-bottom: 1px solid $border-color;
+    padding: 0 24px;
+    height: 64px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    
+    .toolbar-left {
+      display: flex;
+      align-items: center;
+      gap: 24px;
+      
+      .menu-toggle {
+        color: $text-primary;
+        
+        &:hover {
+          background: rgba(0,0,0,0.04);
+        }
+      }
+      
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        
+        .breadcrumb-item {
+          color: $text-secondary;
+          font-size: 14px;
+          
+          &.active {
+            color: $primary-color;
+            font-weight: 500;
+          }
+        }
+        
+        .breadcrumb-separator {
+          font-size: 16px;
+          color: $text-secondary;
+        }
+      }
+    }
+    
+    .toolbar-right {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      
+      .notification-btn, .profile-btn {
+        color: $text-primary;
+        
+        &:hover {
+          background: rgba(0,0,0,0.04);
+        }
+      }
+    }
+  }
+  
+  .page-content {
+    padding: 24px;
+    min-height: calc(100vh - 64px);
+  }
 }
-.content {
-  padding: 1rem;
+
+// Responsive Design
+@media (max-width: 768px) {
+  .admin-sidenav {
+    width: 240px;
+  }
+  
+  .top-toolbar {
+    padding: 0 16px;
+    
+    .breadcrumb {
+      display: none;
+    }
+  }
+  
+  .page-content {
+    padding: 16px;
+  }
+}
+
+@media (max-width: 480px) {
+  .admin-sidenav {
+    width: 100%;
+  }
+  
+  .page-content {
+    padding: 12px;
+  }
 }

--- a/src/app/pages/admin/admin.component.ts
+++ b/src/app/pages/admin/admin.component.ts
@@ -1,147 +1,28 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
-import { MatTableModule } from '@angular/material/table';
-import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatSelectModule } from '@angular/material/select';
-import { FormSubmissionService } from '../../services/form-submission.service';
-import { FormSubmission, JoinUsFormData } from '../../models/form-submission.model';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
 
 @Component({
   selector: 'app-admin',
   standalone: true,
   imports: [
     CommonModule,
+    RouterOutlet,
+    RouterLink,
+    RouterLinkActive,
     MatSidenavModule,
     MatToolbarModule,
-    MatButtonModule,
-    MatIconModule,
     MatListModule,
-    MatTableModule,
-    MatSnackBarModule,
-    MatDialogModule,
-    ReactiveFormsModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatSelectModule
+    MatIconModule,
+    MatButtonModule
   ],
   templateUrl: './admin.component.html',
   styleUrls: ['./admin.component.scss']
 })
-export class AdminComponent implements OnInit {
-  submissions: FormSubmission[] = [];
-  displayedColumns = ['user', 'formType', 'timestamp', 'status', 'actions'];
-
-  private service = inject(FormSubmissionService);
-  private snackBar = inject(MatSnackBar);
-  private dialog = inject(MatDialog);
-  private fb = inject(FormBuilder);
-
-  ngOnInit() {
-    this.loadSubmissions();
-  }
-
-  loadSubmissions() {
-    this.service.getAllSubmissions().subscribe(data => {
-      this.submissions = data;
-    });
-  }
-
-  deleteSubmission(id: string) {
-    this.service.deleteSubmission(id).subscribe(() => {
-      this.snackBar.open('הפריט נמחק', 'סגור', { duration: 2000 });
-      this.loadSubmissions();
-    });
-  }
-
-  markProcessed(submission: FormSubmission) {
-    if (!submission.id) return;
-    this.service.updateSubmission(submission.id, { status: 'approved' }).subscribe(() => {
-      this.snackBar.open('העודכן', 'סגור', { duration: 2000 });
-      this.loadSubmissions();
-    });
-  }
-
-  openAddDialog() {
-    const dialogRef = this.dialog.open(AddSubmissionDialogComponent, {
-      width: '400px'
-    });
-    dialogRef.afterClosed().subscribe(result => {
-      if (result) {
-        this.snackBar.open('נוסף בהצלחה', 'סגור', { duration: 2000 });
-        this.loadSubmissions();
-      }
-    });
-  }
-}
-
-@Component({
-  selector: 'app-add-submission-dialog',
-  standalone: true,
-  imports: [
-    CommonModule,
-    ReactiveFormsModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatSelectModule,
-    MatButtonModule
-  ],
-  template: `
-  <h2 mat-dialog-title>הוספת הגשה</h2>
-  <form [formGroup]="form" class="dialog-form" mat-dialog-content>
-    <mat-form-field appearance="fill">
-      <mat-label>שם מלא</mat-label>
-      <input matInput formControlName="full_name" required />
-    </mat-form-field>
-    <mat-form-field appearance="fill">
-      <mat-label>טלפון</mat-label>
-      <input matInput formControlName="phone" required />
-    </mat-form-field>
-    <mat-form-field appearance="fill">
-      <mat-label>אימייל</mat-label>
-      <input matInput formControlName="email" />
-    </mat-form-field>
-  </form>
-  <div mat-dialog-actions>
-    <button mat-button mat-dialog-close>ביטול</button>
-    <button mat-flat-button color="primary" (click)="submit()" [disabled]="form.invalid">שמור</button>
-  </div>
-  `,
-  styles: [
-    `.dialog-form { display: flex; flex-direction: column; gap: 1rem; width: 100%; }`
-  ]
-})
-export class AddSubmissionDialogComponent {
-  private fb = inject(FormBuilder);
-  private service = inject(FormSubmissionService);
-  private dialogRef = inject(MatDialog);
-
-  form = this.fb.nonNullable.group({
-    full_name: ['', Validators.required],
-    phone: ['', Validators.required],
-    email: ['']
-  });
-
-  submit() {
-    const data: JoinUsFormData = {
-      full_name: this.form.value.full_name!,
-      phone: this.form.value.phone!,
-      email: this.form.value.email || '',
-      specialty: 'other',
-      availability: '',
-      experience: '',
-      specialty_other: ''
-    };
-    this.service.submitJoinUsForm(data).subscribe(() => {
-      this.dialogRef.closeAll();
-    });
-  }
+export class AdminComponent {}
 }

--- a/src/app/pages/admin/admin.component.ts
+++ b/src/app/pages/admin/admin.component.ts
@@ -1,0 +1,146 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
+import { MatTableModule } from '@angular/material/table';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { FormSubmissionService } from '../../services/form-submission.service';
+import { FormSubmission, JoinUsFormData } from '../../models/form-submission.model';
+
+@Component({
+  selector: 'app-admin',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatSidenavModule,
+    MatToolbarModule,
+    MatButtonModule,
+    MatIconModule,
+    MatListModule,
+    MatTableModule,
+    MatSnackBarModule,
+    MatDialogModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule
+  ],
+  templateUrl: './admin.component.html',
+  styleUrls: ['./admin.component.scss']
+})
+export class AdminComponent implements OnInit {
+  submissions: FormSubmission[] = [];
+  displayedColumns = ['user', 'formType', 'timestamp', 'status', 'actions'];
+
+  private service = inject(FormSubmissionService);
+  private snackBar = inject(MatSnackBar);
+  private dialog = inject(MatDialog);
+  private fb = inject(FormBuilder);
+
+  ngOnInit() {
+    this.loadSubmissions();
+  }
+
+  loadSubmissions() {
+    this.service.getAllSubmissions().subscribe(data => {
+      this.submissions = data;
+    });
+  }
+
+  deleteSubmission(id: string) {
+    this.service.deleteSubmission(id).subscribe(() => {
+      this.snackBar.open('הפריט נמחק', 'סגור', { duration: 2000 });
+      this.loadSubmissions();
+    });
+  }
+
+  markProcessed(submission: FormSubmission) {
+    if (!submission.id) return;
+    this.service.updateSubmission(submission.id, { status: 'processed' }).subscribe(() => {
+      this.snackBar.open('העודכן', 'סגור', { duration: 2000 });
+      this.loadSubmissions();
+    });
+  }
+
+  openAddDialog() {
+    const dialogRef = this.dialog.open(AddSubmissionDialogComponent, {
+      width: '400px'
+    });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.snackBar.open('נוסף בהצלחה', 'סגור', { duration: 2000 });
+        this.loadSubmissions();
+      }
+    });
+  }
+}
+
+@Component({
+  selector: 'app-add-submission-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatButtonModule
+  ],
+  template: `
+  <h2 mat-dialog-title>הוספת הגשה</h2>
+  <form [formGroup]="form" class="dialog-form" mat-dialog-content>
+    <mat-form-field appearance="fill">
+      <mat-label>שם מלא</mat-label>
+      <input matInput formControlName="full_name" required />
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>טלפון</mat-label>
+      <input matInput formControlName="phone" required />
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>אימייל</mat-label>
+      <input matInput formControlName="email" />
+    </mat-form-field>
+  </form>
+  <div mat-dialog-actions>
+    <button mat-button mat-dialog-close>ביטול</button>
+    <button mat-flat-button color="primary" (click)="submit()" [disabled]="form.invalid">שמור</button>
+  </div>
+  `,
+  styles: [
+    `.dialog-form { display: flex; flex-direction: column; gap: 1rem; width: 100%; }`
+  ]
+})
+export class AddSubmissionDialogComponent {
+  form = this.fb.nonNullable.group({
+    full_name: ['', Validators.required],
+    phone: ['', Validators.required],
+    email: ['']
+  });
+  private fb = inject(FormBuilder);
+  private service = inject(FormSubmissionService);
+  private dialogRef = inject(MatDialog);
+
+  submit() {
+    const data: JoinUsFormData = {
+      full_name: this.form.value.full_name,
+      phone: this.form.value.phone,
+      email: this.form.value.email || '',
+      specialty: 'other',
+      availability: '',
+      experience: '',
+      specialty_other: ''
+    };
+    this.service.submitJoinUsForm(data).subscribe(() => {
+      this.dialogRef.closeAll();
+    });
+  }
+}

--- a/src/app/pages/admin/admin.component.ts
+++ b/src/app/pages/admin/admin.component.ts
@@ -64,7 +64,7 @@ export class AdminComponent implements OnInit {
 
   markProcessed(submission: FormSubmission) {
     if (!submission.id) return;
-    this.service.updateSubmission(submission.id, { status: 'processed' }).subscribe(() => {
+    this.service.updateSubmission(submission.id, { status: 'approved' }).subscribe(() => {
       this.snackBar.open('העודכן', 'סגור', { duration: 2000 });
       this.loadSubmissions();
     });
@@ -120,19 +120,20 @@ export class AdminComponent implements OnInit {
   ]
 })
 export class AddSubmissionDialogComponent {
+  private fb = inject(FormBuilder);
+  private service = inject(FormSubmissionService);
+  private dialogRef = inject(MatDialog);
+
   form = this.fb.nonNullable.group({
     full_name: ['', Validators.required],
     phone: ['', Validators.required],
     email: ['']
   });
-  private fb = inject(FormBuilder);
-  private service = inject(FormSubmissionService);
-  private dialogRef = inject(MatDialog);
 
   submit() {
     const data: JoinUsFormData = {
-      full_name: this.form.value.full_name,
-      phone: this.form.value.phone,
+      full_name: this.form.value.full_name!,
+      phone: this.form.value.phone!,
       email: this.form.value.email || '',
       specialty: 'other',
       availability: '',

--- a/src/app/pages/admin/admin.component.ts
+++ b/src/app/pages/admin/admin.component.ts
@@ -1,11 +1,12 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
+import { RouterOutlet, RouterLink, RouterLinkActive, Router } from '@angular/router';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatListModule } from '@angular/material/list';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
+import { MatBadgeModule } from '@angular/material/badge';
 
 @Component({
   selector: 'app-admin',
@@ -19,10 +20,29 @@ import { MatButtonModule } from '@angular/material/button';
     MatToolbarModule,
     MatListModule,
     MatIconModule,
-    MatButtonModule
+    MatButtonModule,
+    MatBadgeModule
   ],
   templateUrl: './admin.component.html',
   styleUrls: ['./admin.component.scss']
 })
-export class AdminComponent {}
+export class AdminComponent {
+  constructor(private router: Router) {}
+
+  getCurrentPageTitle(): string {
+    const url = this.router.url;
+    if (url.includes('dashboard')) return 'דשבורד';
+    if (url.includes('submissions')) return 'הגשות';
+    if (url.includes('activities')) return 'פעילויות';
+    if (url.includes('members')) return 'חברי קהילה';
+    if (url.includes('settings')) return 'הגדרות';
+    return 'דשבורד';
+  }
+
+  logout(): void {
+    // Add logout logic here
+    console.log('Logout clicked');
+    // Navigate to home page or login page
+    this.router.navigate(['/']);
+  }
 }

--- a/src/app/pages/admin/dashboard/dashboard.component.html
+++ b/src/app/pages/admin/dashboard/dashboard.component.html
@@ -1,0 +1,6 @@
+<mat-card>
+  <mat-card-title>דשבורד</mat-card-title>
+  <mat-card-content>
+    <p>בחר פריט בתפריט כדי להתחיל.</p>
+  </mat-card-content>
+</mat-card>

--- a/src/app/pages/admin/dashboard/dashboard.component.html
+++ b/src/app/pages/admin/dashboard/dashboard.component.html
@@ -1,6 +1,212 @@
-<mat-card>
-  <mat-card-title>דשבורד</mat-card-title>
-  <mat-card-content>
-    <p>בחר פריט בתפריט כדי להתחיל.</p>
-  </mat-card-content>
-</mat-card>
+<div class="dashboard-page">
+  <!-- Welcome Section -->
+  <div class="welcome-section">
+    <div class="welcome-content">
+      <div class="welcome-text">
+        <h1 class="welcome-title">ברוכים הבאים ללוח הניהול</h1>
+        <p class="welcome-subtitle">ניהול קהילת קו טאו סאנפלואר</p>
+      </div>
+      <div class="welcome-actions">
+        <button mat-flat-button color="primary" class="quick-action-btn">
+          <mat-icon>add</mat-icon>
+          הוסף פעילות חדשה
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Quick Stats -->
+  <div class="quick-stats-grid">
+    <mat-card class="stat-card">
+      <div class="stat-content">
+        <div class="stat-icon members">
+          <mat-icon>people</mat-icon>
+        </div>
+        <div class="stat-info">
+          <h3 class="stat-number">156</h3>
+          <p class="stat-label">חברי קהילה</p>
+          <span class="stat-change positive">+12% מהחודש שעבר</span>
+        </div>
+      </div>
+    </mat-card>
+
+    <mat-card class="stat-card">
+      <div class="stat-content">
+        <div class="stat-icon activities">
+          <mat-icon>event</mat-icon>
+        </div>
+        <div class="stat-info">
+          <h3 class="stat-number">24</h3>
+          <p class="stat-label">פעילויות פעילות</p>
+          <span class="stat-change positive">+3 השבוע</span>
+        </div>
+      </div>
+    </mat-card>
+
+    <mat-card class="stat-card">
+      <div class="stat-content">
+        <div class="stat-icon submissions">
+          <mat-icon>assignment</mat-icon>
+        </div>
+        <div class="stat-info">
+          <h3 class="stat-number">89</h3>
+          <p class="stat-label">הגשות חדשות</p>
+          <span class="stat-change neutral">+5 היום</span>
+        </div>
+      </div>
+    </mat-card>
+
+    <mat-card class="stat-card">
+      <div class="stat-content">
+        <div class="stat-icon revenue">
+          <mat-icon>trending_up</mat-icon>
+        </div>
+        <div class="stat-info">
+          <h3 class="stat-number">₪12,450</h3>
+          <p class="stat-label">הכנסות החודש</p>
+          <span class="stat-change positive">+8% מהחודש שעבר</span>
+        </div>
+      </div>
+    </mat-card>
+  </div>
+
+  <!-- Main Content Grid -->
+  <div class="main-content-grid">
+    <!-- Recent Activity -->
+    <mat-card class="activity-card">
+      <mat-card-header>
+        <mat-card-title>פעילות אחרונה</mat-card-title>
+        <mat-card-subtitle>הפעילויות האחרונות בקהילה</mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content>
+        <div class="activity-list">
+          <div class="activity-item">
+            <div class="activity-icon">
+              <mat-icon>person_add</mat-icon>
+            </div>
+            <div class="activity-content">
+              <h4 class="activity-title">חבר חדש הצטרף</h4>
+              <p class="activity-description">שרה כהן הצטרפה לקהילה</p>
+              <span class="activity-time">לפני 2 שעות</span>
+            </div>
+          </div>
+
+          <div class="activity-item">
+            <div class="activity-icon">
+              <mat-icon>event</mat-icon>
+            </div>
+            <div class="activity-content">
+              <h4 class="activity-title">פעילות חדשה נוצרה</h4>
+              <p class="activity-description">צלילות בים הפתוח - 15 בדצמבר</p>
+              <span class="activity-time">לפני 4 שעות</span>
+            </div>
+          </div>
+
+          <div class="activity-item">
+            <div class="activity-icon">
+              <mat-icon>assignment</mat-icon>
+            </div>
+            <div class="activity-content">
+              <h4 class="activity-title">הגשה חדשה התקבלה</h4>
+              <p class="activity-description">הרשמה לפעילות צלילות</p>
+              <span class="activity-time">לפני 6 שעות</span>
+            </div>
+          </div>
+
+          <div class="activity-item">
+            <div class="activity-icon">
+              <mat-icon>check_circle</mat-icon>
+            </div>
+            <div class="activity-content">
+              <h4 class="activity-title">הגשה אושרה</h4>
+              <p class="activity-description">הרשמה של דוד לוי אושרה</p>
+              <span class="activity-time">לפני 8 שעות</span>
+            </div>
+          </div>
+        </div>
+      </mat-card-content>
+    </mat-card>
+
+    <!-- Upcoming Activities -->
+    <mat-card class="upcoming-card">
+      <mat-card-header>
+        <mat-card-title>פעילויות קרובות</mat-card-title>
+        <mat-card-subtitle>הפעילויות הבאות בקהילה</mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content>
+        <div class="upcoming-list">
+          <div class="upcoming-item">
+            <div class="upcoming-date">
+              <span class="day">15</span>
+              <span class="month">דצמ</span>
+            </div>
+            <div class="upcoming-content">
+              <h4 class="upcoming-title">צלילות בים הפתוח</h4>
+              <p class="upcoming-location">קו טאו, תאילנד</p>
+              <span class="upcoming-participants">12/15 משתתפים</span>
+            </div>
+            <div class="upcoming-status">
+              <span class="status-badge active">פעיל</span>
+            </div>
+          </div>
+
+          <div class="upcoming-item">
+            <div class="upcoming-date">
+              <span class="day">18</span>
+              <span class="month">דצמ</span>
+            </div>
+            <div class="upcoming-content">
+              <h4 class="upcoming-title">סדנת יוגה על החוף</h4>
+              <p class="upcoming-location">חוף סאירי, קו טאו</p>
+              <span class="upcoming-participants">8/20 משתתפים</span>
+            </div>
+            <div class="upcoming-status">
+              <span class="status-badge active">פעיל</span>
+            </div>
+          </div>
+
+          <div class="upcoming-item">
+            <div class="upcoming-date">
+              <span class="day">22</span>
+              <span class="month">דצמ</span>
+            </div>
+            <div class="upcoming-content">
+              <h4 class="upcoming-title">טיול ג'ונגל</h4>
+              <p class="upcoming-location">ג'ונגל קו טאו</p>
+              <span class="upcoming-participants">5/12 משתתפים</span>
+            </div>
+            <div class="upcoming-status">
+              <span class="status-badge upcoming">קרוב</span>
+            </div>
+          </div>
+        </div>
+      </mat-card-content>
+    </mat-card>
+  </div>
+
+  <!-- Quick Actions -->
+  <div class="quick-actions-section">
+    <h2 class="section-title">פעולות מהירות</h2>
+    <div class="actions-grid">
+      <button mat-stroked-button class="action-button" routerLink="/admin/submissions">
+        <mat-icon>assignment</mat-icon>
+        <span>ניהול הגשות</span>
+      </button>
+      
+      <button mat-stroked-button class="action-button" routerLink="/admin/activities">
+        <mat-icon>event</mat-icon>
+        <span>ניהול פעילויות</span>
+      </button>
+      
+      <button mat-stroked-button class="action-button" routerLink="/admin/members">
+        <mat-icon>people</mat-icon>
+        <span>ניהול חברים</span>
+      </button>
+      
+      <button mat-stroked-button class="action-button" routerLink="/admin/settings">
+        <mat-icon>settings</mat-icon>
+        <span>הגדרות</span>
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/admin/dashboard/dashboard.component.scss
+++ b/src/app/pages/admin/dashboard/dashboard.component.scss
@@ -1,0 +1,1 @@
+/* Empty placeholder */

--- a/src/app/pages/admin/dashboard/dashboard.component.scss
+++ b/src/app/pages/admin/dashboard/dashboard.component.scss
@@ -1,1 +1,437 @@
 /* Empty placeholder */
+
+// Variables
+$primary-color: #1976d2;
+$primary-light: #42a5f5;
+$primary-dark: #1565c0;
+$accent-color: #ff9800;
+$success-color: #4caf50;
+$warning-color: #ff9800;
+$error-color: #f44336;
+$text-primary: #212121;
+$text-secondary: #757575;
+$background-light: #fafafa;
+$background-dark: #f5f5f5;
+$border-color: #e0e0e0;
+$shadow-light: 0 2px 4px rgba(0,0,0,0.1);
+$shadow-medium: 0 4px 8px rgba(0,0,0,0.12);
+$shadow-heavy: 0 8px 16px rgba(0,0,0,0.15);
+
+// Dashboard Page
+.dashboard-page {
+  padding: 0;
+  background: $background-light;
+  min-height: 100%;
+}
+
+// Welcome Section
+.welcome-section {
+  background: linear-gradient(135deg, $primary-color 0%, $primary-dark 100%);
+  padding: 32px 24px;
+  margin-bottom: 32px;
+  border-radius: 12px;
+  box-shadow: $shadow-medium;
+  
+  .welcome-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    
+    .welcome-text {
+      .welcome-title {
+        color: white;
+        font-size: 32px;
+        font-weight: 700;
+        margin: 0 0 8px;
+      }
+      
+      .welcome-subtitle {
+        color: rgba(255,255,255,0.9);
+        font-size: 16px;
+        margin: 0;
+      }
+    }
+    
+    .welcome-actions {
+      .quick-action-btn {
+        background: rgba(255,255,255,0.2);
+        color: white;
+        border: 1px solid rgba(255,255,255,0.3);
+        padding: 12px 24px;
+        border-radius: 8px;
+        font-weight: 500;
+        transition: all 0.3s ease;
+        
+        &:hover {
+          background: rgba(255,255,255,0.3);
+          transform: translateY(-2px);
+        }
+        
+        mat-icon {
+          margin-right: 8px;
+        }
+      }
+    }
+  }
+}
+
+// Quick Stats Grid
+.quick-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+  margin-bottom: 32px;
+  
+  .stat-card {
+    border-radius: 12px;
+    box-shadow: $shadow-light;
+    transition: all 0.3s ease;
+    overflow: hidden;
+    
+    &:hover {
+      transform: translateY(-4px);
+      box-shadow: $shadow-medium;
+    }
+    
+    .stat-content {
+      display: flex;
+      align-items: center;
+      padding: 24px;
+      
+      .stat-icon {
+        width: 64px;
+        height: 64px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-right: 20px;
+        
+        mat-icon {
+          font-size: 32px;
+          color: white;
+        }
+        
+        &.members {
+          background: linear-gradient(135deg, #4caf50, #66bb6a);
+        }
+        
+        &.activities {
+          background: linear-gradient(135deg, #ff9800, #ffb74d);
+        }
+        
+        &.submissions {
+          background: linear-gradient(135deg, #2196f3, #42a5f5);
+        }
+        
+        &.revenue {
+          background: linear-gradient(135deg, #9c27b0, #ba68c8);
+        }
+      }
+      
+      .stat-info {
+        flex: 1;
+        
+        .stat-number {
+          font-size: 36px;
+          font-weight: 700;
+          color: $text-primary;
+          margin: 0 0 4px;
+        }
+        
+        .stat-label {
+          color: $text-secondary;
+          font-size: 14px;
+          margin: 0 0 8px;
+        }
+        
+        .stat-change {
+          font-size: 12px;
+          font-weight: 500;
+          
+          &.positive {
+            color: $success-color;
+          }
+          
+          &.negative {
+            color: $error-color;
+          }
+          
+          &.neutral {
+            color: $text-secondary;
+          }
+        }
+      }
+    }
+  }
+}
+
+// Main Content Grid
+.main-content-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  margin-bottom: 32px;
+  
+  .activity-card, .upcoming-card {
+    border-radius: 12px;
+    box-shadow: $shadow-light;
+    overflow: hidden;
+    
+    mat-card-header {
+      background: $background-dark;
+      padding: 20px 24px;
+      
+      mat-card-title {
+        font-size: 20px;
+        font-weight: 600;
+        color: $text-primary;
+        margin: 0;
+      }
+      
+      mat-card-subtitle {
+        color: $text-secondary;
+        margin: 4px 0 0;
+      }
+    }
+    
+    mat-card-content {
+      padding: 0;
+    }
+  }
+}
+
+// Activity List
+.activity-list {
+  .activity-item {
+    display: flex;
+    align-items: center;
+    padding: 20px 24px;
+    border-bottom: 1px solid $border-color;
+    transition: background-color 0.2s ease;
+    
+    &:last-child {
+      border-bottom: none;
+    }
+    
+    &:hover {
+      background: rgba(0,0,0,0.02);
+    }
+    
+    .activity-icon {
+      width: 48px;
+      height: 48px;
+      background: rgba($primary-color, 0.1);
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-right: 16px;
+      
+      mat-icon {
+        color: $primary-color;
+        font-size: 20px;
+      }
+    }
+    
+    .activity-content {
+      flex: 1;
+      
+      .activity-title {
+        font-size: 16px;
+        font-weight: 600;
+        color: $text-primary;
+        margin: 0 0 4px;
+      }
+      
+      .activity-description {
+        color: $text-secondary;
+        font-size: 14px;
+        margin: 0 0 4px;
+      }
+      
+      .activity-time {
+        color: $text-secondary;
+        font-size: 12px;
+      }
+    }
+  }
+}
+
+// Upcoming List
+.upcoming-list {
+  .upcoming-item {
+    display: flex;
+    align-items: center;
+    padding: 20px 24px;
+    border-bottom: 1px solid $border-color;
+    transition: background-color 0.2s ease;
+    
+    &:last-child {
+      border-bottom: none;
+    }
+    
+    &:hover {
+      background: rgba(0,0,0,0.02);
+    }
+    
+    .upcoming-date {
+      width: 60px;
+      height: 60px;
+      background: $primary-color;
+      border-radius: 8px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      margin-right: 16px;
+      
+      .day {
+        color: white;
+        font-size: 20px;
+        font-weight: 700;
+        line-height: 1;
+      }
+      
+      .month {
+        color: rgba(255,255,255,0.9);
+        font-size: 12px;
+        font-weight: 500;
+      }
+    }
+    
+    .upcoming-content {
+      flex: 1;
+      
+      .upcoming-title {
+        font-size: 16px;
+        font-weight: 600;
+        color: $text-primary;
+        margin: 0 0 4px;
+      }
+      
+      .upcoming-location {
+        color: $text-secondary;
+        font-size: 14px;
+        margin: 0 0 4px;
+      }
+      
+      .upcoming-participants {
+        color: $text-secondary;
+        font-size: 12px;
+      }
+    }
+    
+    .upcoming-status {
+      .status-badge {
+        padding: 4px 12px;
+        border-radius: 20px;
+        font-size: 12px;
+        font-weight: 500;
+        
+        &.active {
+          background: rgba($success-color, 0.1);
+          color: $success-color;
+        }
+        
+        &.upcoming {
+          background: rgba($warning-color, 0.1);
+          color: $warning-color;
+        }
+      }
+    }
+  }
+}
+
+// Quick Actions Section
+.quick-actions-section {
+  .section-title {
+    font-size: 24px;
+    font-weight: 600;
+    color: $text-primary;
+    margin: 0 0 24px;
+  }
+  
+  .actions-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 16px;
+    
+    .action-button {
+      height: 80px;
+      border-radius: 12px;
+      border: 2px solid $border-color;
+      background: white;
+      transition: all 0.3s ease;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      
+      &:hover {
+        border-color: $primary-color;
+        background: rgba($primary-color, 0.02);
+        transform: translateY(-2px);
+        box-shadow: $shadow-light;
+      }
+      
+      mat-icon {
+        font-size: 24px;
+        color: $primary-color;
+      }
+      
+      span {
+        font-size: 14px;
+        font-weight: 500;
+        color: $text-primary;
+      }
+    }
+  }
+}
+
+// Responsive Design
+@media (max-width: 1024px) {
+  .main-content-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .welcome-section {
+    padding: 24px 16px;
+    
+    .welcome-content {
+      flex-direction: column;
+      gap: 16px;
+      text-align: center;
+      
+      .welcome-title {
+        font-size: 24px;
+      }
+    }
+  }
+  
+  .quick-stats-grid {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 16px;
+  }
+  
+  .actions-grid {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  }
+}
+
+@media (max-width: 480px) {
+  .quick-stats-grid {
+    grid-template-columns: 1fr;
+  }
+  
+  .actions-grid {
+    grid-template-columns: 1fr;
+  }
+  
+  .activity-item, .upcoming-item {
+    padding: 16px;
+  }
+}

--- a/src/app/pages/admin/dashboard/dashboard.component.ts
+++ b/src/app/pages/admin/dashboard/dashboard.component.ts
@@ -1,11 +1,20 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
 import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'app-admin-dashboard',
   standalone: true,
-  imports: [CommonModule, MatCardModule],
+  imports: [
+    CommonModule,
+    RouterLink,
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule
+  ],
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.scss']
 })

--- a/src/app/pages/admin/dashboard/dashboard.component.ts
+++ b/src/app/pages/admin/dashboard/dashboard.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+
+@Component({
+  selector: 'app-admin-dashboard',
+  standalone: true,
+  imports: [CommonModule, MatCardModule],
+  templateUrl: './dashboard.component.html',
+  styleUrls: ['./dashboard.component.scss']
+})
+export class DashboardComponent {}

--- a/src/app/pages/admin/submissions.component.html
+++ b/src/app/pages/admin/submissions.component.html
@@ -1,39 +1,192 @@
-<div class="submissions-header">
-  <button mat-flat-button color="primary" (click)="openAddDialog()">
-    <mat-icon>add</mat-icon>
-    הוסף
-  </button>
-</div>
-<div class="content">
-  <table mat-table [dataSource]="submissions" class="mat-elevation-z1" multiTemplateDataRows>
-        <ng-container matColumnDef="user">
-          <th mat-header-cell *matHeaderCellDef>משתמש</th>
-          <td mat-cell *matCellDef="let s">{{ s.userIdentity }}</td>
-        </ng-container>
-        <ng-container matColumnDef="formType">
-          <th mat-header-cell *matHeaderCellDef>טופס</th>
-          <td mat-cell *matCellDef="let s">{{ s.formName }}</td>
-        </ng-container>
-        <ng-container matColumnDef="timestamp">
-          <th mat-header-cell *matHeaderCellDef>תאריך</th>
-          <td mat-cell *matCellDef="let s">{{ s.timestamp | date:'short' }}</td>
-        </ng-container>
-        <ng-container matColumnDef="status">
-          <th mat-header-cell *matHeaderCellDef>סטטוס</th>
-          <td mat-cell *matCellDef="let s">{{ s.status }}</td>
-        </ng-container>
-        <ng-container matColumnDef="actions">
-          <th mat-header-cell *matHeaderCellDef>פעולות</th>
-          <td mat-cell *matCellDef="let s">
-            <button mat-icon-button color="primary" (click)="markProcessed(s)">
-              <mat-icon>check</mat-icon>
-            </button>
-            <button mat-icon-button color="warn" (click)="deleteSubmission(s.id!)">
-              <mat-icon>delete</mat-icon>
-            </button>
-          </td>
-        </ng-container>
-        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-  </table>
+<div class="submissions-page">
+  <!-- Page Header -->
+  <div class="page-header">
+    <div class="header-content">
+      <div class="header-left">
+        <h1 class="page-title">הגשות</h1>
+        <p class="page-subtitle">ניהול כל ההגשות והטפסים</p>
+      </div>
+      <div class="header-right">
+        <button mat-flat-button color="primary" class="add-btn" (click)="openAddDialog()">
+          <mat-icon>add</mat-icon>
+          הוסף הגשה חדשה
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Stats Cards -->
+  <div class="stats-grid">
+    <mat-card class="stat-card">
+      <div class="stat-content">
+        <div class="stat-icon pending">
+          <mat-icon>schedule</mat-icon>
+        </div>
+        <div class="stat-info">
+          <h3 class="stat-number">{{ getPendingCount() }}</h3>
+          <p class="stat-label">ממתינות</p>
+        </div>
+      </div>
+    </mat-card>
+
+    <mat-card class="stat-card">
+      <div class="stat-content">
+        <div class="stat-icon approved">
+          <mat-icon>check_circle</mat-icon>
+        </div>
+        <div class="stat-info">
+          <h3 class="stat-number">{{ getApprovedCount() }}</h3>
+          <p class="stat-label">אושרו</p>
+        </div>
+      </div>
+    </mat-card>
+
+    <mat-card class="stat-card">
+      <div class="stat-content">
+        <div class="stat-icon rejected">
+          <mat-icon>cancel</mat-icon>
+        </div>
+        <div class="stat-info">
+          <h3 class="stat-number">{{ getRejectedCount() }}</h3>
+          <p class="stat-label">נדחו</p>
+        </div>
+      </div>
+    </mat-card>
+
+    <mat-card class="stat-card">
+      <div class="stat-content">
+        <div class="stat-icon total">
+          <mat-icon>assignment</mat-icon>
+        </div>
+        <div class="stat-info">
+          <h3 class="stat-number">{{ submissions.length }}</h3>
+          <p class="stat-label">סה"כ הגשות</p>
+        </div>
+      </div>
+    </mat-card>
+  </div>
+
+  <!-- Submissions Table -->
+  <mat-card class="table-card">
+    <mat-card-header>
+      <mat-card-title>רשימת הגשות</mat-card-title>
+      <mat-card-subtitle>כל ההגשות והטפסים שהתקבלו</mat-card-subtitle>
+    </mat-card-header>
+    
+    <mat-card-content>
+      <div class="table-container">
+        <table mat-table [dataSource]="submissions" class="submissions-table" multiTemplateDataRows>
+          <!-- User Column -->
+          <ng-container matColumnDef="user">
+            <th mat-header-cell *matHeaderCellDef class="table-header">
+              <div class="header-content">
+                <mat-icon>person</mat-icon>
+                <span>משתמש</span>
+              </div>
+            </th>
+            <td mat-cell *matCellDef="let submission" class="user-cell">
+              <div class="user-info">
+                <div class="user-avatar">
+                  <mat-icon>account_circle</mat-icon>
+                </div>
+                <div class="user-details">
+                  <span class="user-name">{{ submission.userIdentity }}</span>
+                  <span class="user-email" *ngIf="submission.data.email">{{ submission.data.email }}</span>
+                </div>
+              </div>
+            </td>
+          </ng-container>
+
+          <!-- Form Type Column -->
+          <ng-container matColumnDef="formType">
+            <th mat-header-cell *matHeaderCellDef class="table-header">
+              <div class="header-content">
+                <mat-icon>description</mat-icon>
+                <span>סוג טופס</span>
+              </div>
+            </th>
+            <td mat-cell *matCellDef="let submission" class="form-type-cell">
+              <div class="form-type-badge" [class]="submission.formType">
+                <mat-icon>{{ getFormTypeIcon(submission.formType) }}</mat-icon>
+                <span>{{ submission.formName }}</span>
+              </div>
+            </td>
+          </ng-container>
+
+          <!-- Timestamp Column -->
+          <ng-container matColumnDef="timestamp">
+            <th mat-header-cell *matHeaderCellDef class="table-header">
+              <div class="header-content">
+                <mat-icon>schedule</mat-icon>
+                <span>תאריך</span>
+              </div>
+            </th>
+            <td mat-cell *matCellDef="let submission" class="timestamp-cell">
+              <div class="timestamp-info">
+                <span class="date">{{ submission.timestamp | date:'shortDate' }}</span>
+                <span class="time">{{ submission.timestamp | date:'shortTime' }}</span>
+              </div>
+            </td>
+          </ng-container>
+
+          <!-- Status Column -->
+          <ng-container matColumnDef="status">
+            <th mat-header-cell *matHeaderCellDef class="table-header">
+              <div class="header-content">
+                <mat-icon>flag</mat-icon>
+                <span>סטטוס</span>
+              </div>
+            </th>
+            <td mat-cell *matCellDef="let submission" class="status-cell">
+              <div class="status-badge" [class]="submission.status">
+                <mat-icon>{{ getStatusIcon(submission.status) }}</mat-icon>
+                <span>{{ getStatusText(submission.status) }}</span>
+              </div>
+            </td>
+          </ng-container>
+
+          <!-- Actions Column -->
+          <ng-container matColumnDef="actions">
+            <th mat-header-cell *matHeaderCellDef class="table-header">
+              <div class="header-content">
+                <mat-icon>settings</mat-icon>
+                <span>פעולות</span>
+              </div>
+            </th>
+            <td mat-cell *matCellDef="let submission" class="actions-cell">
+              <div class="action-buttons">
+                <button mat-icon-button 
+                        color="primary" 
+                        class="action-btn approve-btn"
+                        (click)="markProcessed(submission)"
+                        [disabled]="submission.status === 'approved'"
+                        matTooltip="אשר הגשה">
+                  <mat-icon>check</mat-icon>
+                </button>
+                
+                <button mat-icon-button 
+                        color="warn" 
+                        class="action-btn delete-btn"
+                        (click)="deleteSubmission(submission.id!)"
+                        matTooltip="מחק הגשה">
+                  <mat-icon>delete</mat-icon>
+                </button>
+                
+                <button mat-icon-button 
+                        color="accent" 
+                        class="action-btn view-btn"
+                        (click)="viewSubmission(submission)"
+                        matTooltip="צפה בפרטים">
+                  <mat-icon>visibility</mat-icon>
+                </button>
+              </div>
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="displayedColumns" class="table-header-row"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedColumns;" class="table-row"></tr>
+        </table>
+      </div>
+    </mat-card-content>
+  </mat-card>
 </div>

--- a/src/app/pages/admin/submissions.component.html
+++ b/src/app/pages/admin/submissions.component.html
@@ -1,0 +1,39 @@
+<div class="submissions-header">
+  <button mat-flat-button color="primary" (click)="openAddDialog()">
+    <mat-icon>add</mat-icon>
+    הוסף
+  </button>
+</div>
+<div class="content">
+  <table mat-table [dataSource]="submissions" class="mat-elevation-z1" multiTemplateDataRows>
+        <ng-container matColumnDef="user">
+          <th mat-header-cell *matHeaderCellDef>משתמש</th>
+          <td mat-cell *matCellDef="let s">{{ s.userIdentity }}</td>
+        </ng-container>
+        <ng-container matColumnDef="formType">
+          <th mat-header-cell *matHeaderCellDef>טופס</th>
+          <td mat-cell *matCellDef="let s">{{ s.formName }}</td>
+        </ng-container>
+        <ng-container matColumnDef="timestamp">
+          <th mat-header-cell *matHeaderCellDef>תאריך</th>
+          <td mat-cell *matCellDef="let s">{{ s.timestamp | date:'short' }}</td>
+        </ng-container>
+        <ng-container matColumnDef="status">
+          <th mat-header-cell *matHeaderCellDef>סטטוס</th>
+          <td mat-cell *matCellDef="let s">{{ s.status }}</td>
+        </ng-container>
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef>פעולות</th>
+          <td mat-cell *matCellDef="let s">
+            <button mat-icon-button color="primary" (click)="markProcessed(s)">
+              <mat-icon>check</mat-icon>
+            </button>
+            <button mat-icon-button color="warn" (click)="deleteSubmission(s.id!)">
+              <mat-icon>delete</mat-icon>
+            </button>
+          </td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  </table>
+</div>

--- a/src/app/pages/admin/submissions.component.scss
+++ b/src/app/pages/admin/submissions.component.scss
@@ -1,8 +1,427 @@
-.submissions-header {
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: 1rem;
+// Variables
+$primary-color: #1976d2;
+$primary-light: #42a5f5;
+$primary-dark: #1565c0;
+$accent-color: #ff9800;
+$success-color: #4caf50;
+$warning-color: #ff9800;
+$error-color: #f44336;
+$text-primary: #212121;
+$text-secondary: #757575;
+$background-light: #fafafa;
+$background-dark: #f5f5f5;
+$border-color: #e0e0e0;
+$shadow-light: 0 2px 4px rgba(0,0,0,0.1);
+$shadow-medium: 0 4px 8px rgba(0,0,0,0.12);
+$shadow-heavy: 0 8px 16px rgba(0,0,0,0.15);
+
+// Page Container
+.submissions-page {
+  padding: 0;
+  background: $background-light;
+  min-height: 100%;
 }
-.content {
-  padding: 0 1rem;
+
+// Page Header
+.page-header {
+  background: white;
+  padding: 24px;
+  margin-bottom: 24px;
+  border-radius: 8px;
+  box-shadow: $shadow-light;
+  
+  .header-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    
+    .header-left {
+      .page-title {
+        font-size: 28px;
+        font-weight: 600;
+        color: $text-primary;
+        margin: 0 0 8px;
+      }
+      
+      .page-subtitle {
+        color: $text-secondary;
+        font-size: 14px;
+        margin: 0;
+      }
+    }
+    
+    .header-right {
+      .add-btn {
+        padding: 12px 24px;
+        border-radius: 8px;
+        font-weight: 500;
+        
+        mat-icon {
+          margin-right: 8px;
+        }
+      }
+    }
+  }
+}
+
+// Stats Grid
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 24px;
+  margin-bottom: 32px;
+  
+  .stat-card {
+    border-radius: 12px;
+    box-shadow: $shadow-light;
+    transition: all 0.3s ease;
+    
+    &:hover {
+      transform: translateY(-2px);
+      box-shadow: $shadow-medium;
+    }
+    
+    .stat-content {
+      display: flex;
+      align-items: center;
+      padding: 24px;
+      
+      .stat-icon {
+        width: 60px;
+        height: 60px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-right: 16px;
+        
+        mat-icon {
+          font-size: 28px;
+          color: white;
+        }
+        
+        &.pending {
+          background: linear-gradient(135deg, $warning-color, #ffb74d);
+        }
+        
+        &.approved {
+          background: linear-gradient(135deg, $success-color, #66bb6a);
+        }
+        
+        &.rejected {
+          background: linear-gradient(135deg, $error-color, #ef5350);
+        }
+        
+        &.total {
+          background: linear-gradient(135deg, $primary-color, $primary-light);
+        }
+      }
+      
+      .stat-info {
+        flex: 1;
+        
+        .stat-number {
+          font-size: 32px;
+          font-weight: 700;
+          color: $text-primary;
+          margin: 0 0 4px;
+        }
+        
+        .stat-label {
+          color: $text-secondary;
+          font-size: 14px;
+          margin: 0;
+        }
+      }
+    }
+  }
+}
+
+// Table Card
+.table-card {
+  border-radius: 12px;
+  box-shadow: $shadow-light;
+  overflow: hidden;
+  
+  mat-card-header {
+    background: $background-dark;
+    padding: 20px 24px;
+    
+    mat-card-title {
+      font-size: 20px;
+      font-weight: 600;
+      color: $text-primary;
+      margin: 0;
+    }
+    
+    mat-card-subtitle {
+      color: $text-secondary;
+      margin: 4px 0 0;
+    }
+  }
+  
+  mat-card-content {
+    padding: 0;
+  }
+}
+
+// Table Container
+.table-container {
+  overflow-x: auto;
+  
+  .submissions-table {
+    width: 100%;
+    
+    .table-header {
+      background: $background-dark;
+      padding: 16px 24px;
+      
+      .header-content {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        
+        mat-icon {
+          font-size: 18px;
+          color: $text-secondary;
+        }
+        
+        span {
+          font-weight: 600;
+          color: $text-primary;
+          font-size: 14px;
+        }
+      }
+    }
+    
+    .table-header-row {
+      background: $background-dark;
+    }
+    
+    .table-row {
+      transition: background-color 0.2s ease;
+      
+      &:hover {
+        background: rgba(0,0,0,0.02);
+      }
+      
+      &:nth-child(even) {
+        background: rgba(0,0,0,0.01);
+      }
+    }
+    
+    // User Cell
+    .user-cell {
+      padding: 16px 24px;
+      
+      .user-info {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        
+        .user-avatar {
+          width: 40px;
+          height: 40px;
+          background: $primary-light;
+          border-radius: 50%;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          
+          mat-icon {
+            color: white;
+            font-size: 20px;
+          }
+        }
+        
+        .user-details {
+          display: flex;
+          flex-direction: column;
+          
+          .user-name {
+            font-weight: 500;
+            color: $text-primary;
+            font-size: 14px;
+          }
+          
+          .user-email {
+            color: $text-secondary;
+            font-size: 12px;
+          }
+        }
+      }
+    }
+    
+    // Form Type Cell
+    .form-type-cell {
+      padding: 16px 24px;
+      
+      .form-type-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 12px;
+        border-radius: 20px;
+        font-size: 12px;
+        font-weight: 500;
+        
+        mat-icon {
+          font-size: 16px;
+        }
+        
+        &.join-us {
+          background: rgba($primary-color, 0.1);
+          color: $primary-color;
+        }
+        
+        &.register-activity {
+          background: rgba($accent-color, 0.1);
+          color: $accent-color;
+        }
+      }
+    }
+    
+    // Timestamp Cell
+    .timestamp-cell {
+      padding: 16px 24px;
+      
+      .timestamp-info {
+        display: flex;
+        flex-direction: column;
+        
+        .date {
+          font-weight: 500;
+          color: $text-primary;
+          font-size: 14px;
+        }
+        
+        .time {
+          color: $text-secondary;
+          font-size: 12px;
+        }
+      }
+    }
+    
+    // Status Cell
+    .status-cell {
+      padding: 16px 24px;
+      
+      .status-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 12px;
+        border-radius: 20px;
+        font-size: 12px;
+        font-weight: 500;
+        
+        mat-icon {
+          font-size: 16px;
+        }
+        
+        &.pending {
+          background: rgba($warning-color, 0.1);
+          color: $warning-color;
+        }
+        
+        &.approved {
+          background: rgba($success-color, 0.1);
+          color: $success-color;
+        }
+        
+        &.rejected {
+          background: rgba($error-color, 0.1);
+          color: $error-color;
+        }
+      }
+    }
+    
+    // Actions Cell
+    .actions-cell {
+      padding: 16px 24px;
+      
+      .action-buttons {
+        display: flex;
+        gap: 8px;
+        
+        .action-btn {
+          width: 36px;
+          height: 36px;
+          border-radius: 8px;
+          transition: all 0.2s ease;
+          
+          &:hover {
+            transform: scale(1.1);
+          }
+          
+          &.approve-btn {
+            background: rgba($success-color, 0.1);
+            color: $success-color;
+            
+            &:disabled {
+              background: rgba($text-secondary, 0.1);
+              color: $text-secondary;
+            }
+          }
+          
+          &.delete-btn {
+            background: rgba($error-color, 0.1);
+            color: $error-color;
+          }
+          
+          &.view-btn {
+            background: rgba($primary-color, 0.1);
+            color: $primary-color;
+          }
+        }
+      }
+    }
+  }
+}
+
+// Responsive Design
+@media (max-width: 768px) {
+  .page-header {
+    padding: 16px;
+    
+    .header-content {
+      flex-direction: column;
+      gap: 16px;
+      align-items: flex-start;
+    }
+  }
+  
+  .stats-grid {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 16px;
+  }
+  
+  .table-container {
+    .submissions-table {
+      .user-cell, .form-type-cell, .timestamp-cell, .status-cell, .actions-cell {
+        padding: 12px 16px;
+      }
+      
+      .action-buttons {
+        flex-direction: column;
+        gap: 4px;
+      }
+    }
+  }
+}
+
+@media (max-width: 480px) {
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+  
+  .table-container {
+    .submissions-table {
+      font-size: 12px;
+      
+      .user-cell, .form-type-cell, .timestamp-cell, .status-cell, .actions-cell {
+        padding: 8px 12px;
+      }
+    }
+  }
 }

--- a/src/app/pages/admin/submissions.component.scss
+++ b/src/app/pages/admin/submissions.component.scss
@@ -1,0 +1,8 @@
+.submissions-header {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1rem;
+}
+.content {
+  padding: 0 1rem;
+}

--- a/src/app/pages/admin/submissions.component.ts
+++ b/src/app/pages/admin/submissions.component.ts
@@ -1,0 +1,140 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTableModule } from '@angular/material/table';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { FormSubmissionService } from '../../services/form-submission.service';
+import { FormSubmission, JoinUsFormData } from '../../models/form-submission.model';
+
+@Component({
+  selector: 'app-admin',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatTableModule,
+    MatButtonModule,
+    MatIconModule,
+    MatSnackBarModule,
+    MatDialogModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule
+  ],
+  templateUrl: './submissions.component.html',
+  styleUrls: ['./submissions.component.scss']
+})
+export class SubmissionsComponent implements OnInit {
+  submissions: FormSubmission[] = [];
+  displayedColumns = ['user', 'formType', 'timestamp', 'status', 'actions'];
+
+  private service = inject(FormSubmissionService);
+  private snackBar = inject(MatSnackBar);
+  private dialog = inject(MatDialog);
+  private fb = inject(FormBuilder);
+
+  ngOnInit() {
+    this.loadSubmissions();
+  }
+
+  loadSubmissions() {
+    this.service.getAllSubmissions().subscribe(data => {
+      this.submissions = data;
+    });
+  }
+
+  deleteSubmission(id: string) {
+    this.service.deleteSubmission(id).subscribe(() => {
+      this.snackBar.open('הפריט נמחק', 'סגור', { duration: 2000 });
+      this.loadSubmissions();
+    });
+  }
+
+  markProcessed(submission: FormSubmission) {
+    if (!submission.id) return;
+    this.service.updateSubmission(submission.id, { status: 'processed' }).subscribe(() => {
+      this.snackBar.open('העודכן', 'סגור', { duration: 2000 });
+      this.loadSubmissions();
+    });
+  }
+
+  openAddDialog() {
+    const dialogRef = this.dialog.open(AddSubmissionDialogComponent, {
+      width: '400px'
+    });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.snackBar.open('נוסף בהצלחה', 'סגור', { duration: 2000 });
+        this.loadSubmissions();
+      }
+    });
+  }
+}
+
+@Component({
+  selector: 'app-add-submission-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatButtonModule
+  ],
+  template: `
+  <h2 mat-dialog-title>הוספת הגשה</h2>
+  <form [formGroup]="form" class="dialog-form" mat-dialog-content>
+    <mat-form-field appearance="fill">
+      <mat-label>שם מלא</mat-label>
+      <input matInput formControlName="full_name" required />
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>טלפון</mat-label>
+      <input matInput formControlName="phone" required />
+    </mat-form-field>
+    <mat-form-field appearance="fill">
+      <mat-label>אימייל</mat-label>
+      <input matInput formControlName="email" />
+    </mat-form-field>
+  </form>
+  <div mat-dialog-actions>
+    <button mat-button mat-dialog-close>ביטול</button>
+    <button mat-flat-button color="primary" (click)="submit()" [disabled]="form.invalid">שמור</button>
+  </div>
+  `,
+  styles: [
+    `.dialog-form { display: flex; flex-direction: column; gap: 1rem; width: 100%; }`
+  ]
+})
+export class AddSubmissionDialogComponent {
+  form = this.fb.nonNullable.group({
+    full_name: ['', Validators.required],
+    phone: ['', Validators.required],
+    email: ['']
+  });
+  private fb = inject(FormBuilder);
+  private service = inject(FormSubmissionService);
+  private dialogRef = inject(MatDialog);
+
+  submit() {
+    const data: JoinUsFormData = {
+      full_name: this.form.value.full_name,
+      phone: this.form.value.phone,
+      email: this.form.value.email || '',
+      specialty: 'other',
+      availability: '',
+      experience: '',
+      specialty_other: ''
+    };
+    this.service.submitJoinUsForm(data).subscribe(() => {
+      this.dialogRef.closeAll();
+    });
+  }
+}

--- a/src/app/pages/admin/submissions.component.ts
+++ b/src/app/pages/admin/submissions.component.ts
@@ -9,6 +9,8 @@ import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
+import { MatCardModule } from '@angular/material/card';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { FormSubmissionService } from '../../services/form-submission.service';
 import { FormSubmission, JoinUsFormData } from '../../models/form-submission.model';
 
@@ -25,7 +27,9 @@ import { FormSubmission, JoinUsFormData } from '../../models/form-submission.mod
     ReactiveFormsModule,
     MatFormFieldModule,
     MatInputModule,
-    MatSelectModule
+    MatSelectModule,
+    MatCardModule,
+    MatTooltipModule
   ],
   templateUrl: './submissions.component.html',
   styleUrls: ['./submissions.component.scss']
@@ -37,7 +41,6 @@ export class SubmissionsComponent implements OnInit {
   private service = inject(FormSubmissionService);
   private snackBar = inject(MatSnackBar);
   private dialog = inject(MatDialog);
-  private fb = inject(FormBuilder);
 
   ngOnInit() {
     this.loadSubmissions();
@@ -58,7 +61,7 @@ export class SubmissionsComponent implements OnInit {
 
   markProcessed(submission: FormSubmission) {
     if (!submission.id) return;
-    this.service.updateSubmission(submission.id, { status: 'processed' }).subscribe(() => {
+    this.service.updateSubmission(submission.id, { status: 'approved' }).subscribe(() => {
       this.snackBar.open('העודכן', 'סגור', { duration: 2000 });
       this.loadSubmissions();
     });
@@ -74,6 +77,52 @@ export class SubmissionsComponent implements OnInit {
         this.loadSubmissions();
       }
     });
+  }
+
+  // Statistics methods
+  getPendingCount(): number {
+    return this.submissions.filter(s => s.status === 'pending').length;
+  }
+
+  getApprovedCount(): number {
+    return this.submissions.filter(s => s.status === 'approved').length;
+  }
+
+  getRejectedCount(): number {
+    return this.submissions.filter(s => s.status === 'rejected').length;
+  }
+
+  // UI Helper methods
+  getFormTypeIcon(formType: string): string {
+    const icons: { [key: string]: string } = {
+      'join-us': 'person_add',
+      'register-activity': 'event'
+    };
+    return icons[formType] || 'description';
+  }
+
+  getStatusIcon(status: string): string {
+    const icons: { [key: string]: string } = {
+      'pending': 'schedule',
+      'approved': 'check_circle',
+      'rejected': 'cancel'
+    };
+    return icons[status] || 'help';
+  }
+
+  getStatusText(status: string): string {
+    const texts: { [key: string]: string } = {
+      'pending': 'ממתין',
+      'approved': 'אושר',
+      'rejected': 'נדחה'
+    };
+    return texts[status] || status;
+  }
+
+  viewSubmission(submission: FormSubmission) {
+    // TODO: Implement view submission dialog
+    console.log('View submission:', submission);
+    this.snackBar.open('פונקציונליות צפייה תתווסף בקרוב', 'סגור', { duration: 2000 });
   }
 }
 
@@ -114,19 +163,20 @@ export class SubmissionsComponent implements OnInit {
   ]
 })
 export class AddSubmissionDialogComponent {
+  private fb = inject(FormBuilder);
+  private service = inject(FormSubmissionService);
+  private dialogRef = inject(MatDialog);
+
   form = this.fb.nonNullable.group({
     full_name: ['', Validators.required],
     phone: ['', Validators.required],
     email: ['']
   });
-  private fb = inject(FormBuilder);
-  private service = inject(FormSubmissionService);
-  private dialogRef = inject(MatDialog);
 
   submit() {
     const data: JoinUsFormData = {
-      full_name: this.form.value.full_name,
-      phone: this.form.value.phone,
+      full_name: this.form.value.full_name!,
+      phone: this.form.value.phone!,
       email: this.form.value.email || '',
       specialty: 'other',
       availability: '',


### PR DESCRIPTION
## Summary
- add `/admin` route for a simple admin panel
- show admin link in the header navigation
- implement `AdminComponent` with side nav and a submissions table
- allow marking submissions processed, deleting entries and adding a simple entry

## Testing
- `npx ng test --watch=false` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68580b0765cc8333a8b62c25293465ea